### PR TITLE
Improve buffer get/set using indices

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -58,6 +58,22 @@ function Base.getindex{T<:Integer}(b::Buffer, r::UnitRange{T})
 end
 Base.getindex(b::Buffer, i::Union(OverflowIndex, OverflowRange)) = throw(BoundsError())
 
+Base.setindex!(b::Buffer, lines::Array, r::CappedRange) =
+    set_line_slice(b, r.start, r.stop, true, true, lines)
+Base.setindex!(b::Buffer, s::String, i::Integer) = b[i:i] = [s]
+Base.setindex!(b::Buffer, s::String, i::EndRelIndex) = b[i:i] = [s]
+Base.setindex!(b::Buffer, s::String, r::CappedRange) = b[r] = [s]
+function Base.setindex!{T<:Integer}(b::Buffer, s::String, r::UnitRange{T})
+    ndests = r.stop - r.start + 1
+    ndests <= 0 ? s : b[r] = fill(s, ndests)
+end
+function Base.setindex!{T<:Integer}(b::Buffer, lines::Array, r::UnitRange{T})
+    if (r.start < 1 || r.stop < 1) throw(BoundsError())
+    else b[CappedRange(r.start - 1, r.stop - 1)] = lines
+    end
+end
+Base.setindex!(b::Buffer, s::String, i::Union(OverflowIndex, OverflowRange)) = throw(BoundsError())
+
 Base.push!(b::Buffer, items...) = (insert(b, -1, [items...]); b)
 Base.append!(b::Buffer, items) = (insert(b, -1, items); b)
 Base.unshift!(b::Buffer, items...) = (set_line_slice(b, 0, 0, true, false, [items...]); b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,15 +46,33 @@ buf[:] = ["alpha", "beta", "gamma"]
 @test_throws BoundsError buf[end:end+1]
 @test_throws BoundsError buf[end+1:end+1]
 
-buf[2] = "beta-ish"
+@assert (buf[2] = "beta-ish") == "beta-ish"
 @assert buf[:] == ["alpha", "beta-ish", "gamma"]
-buf[2:3] = ["b", "c", "d"]
+@assert (buf[end] = "gamma-ish") == "gamma-ish"
+@assert buf[:] == ["alpha", "beta-ish", "gamma-ish"]
+@assert (buf[2:3] = ["b", "c", "d"]) == ["b", "c", "d"]
 @assert buf[:] == ["alpha", "b", "c", "d"]
-buf[end-1:end-2] = ["boom"]
+@assert (buf[end-1:end-2] = ["boom"]) == ["boom"]
 @assert buf[:] == ["alpha", "b", "boom", "c", "d"]
+@assert (buf[end-1:1+end-2] = ".") == "."
+@assert buf[:] == ["alpha", "b", "boom", ".", "d"]
+
+@test_throws BoundsError buf[0] = "twas"
+@test_throws BoundsError buf[-1] = "brillyg"
+@test_throws BoundsError buf[end+1] = "and"
+@test_throws BoundsError buf[-1:1] = "the"
+@test_throws BoundsError buf[0:1] = "slythy"
+@test_throws BoundsError buf[-1:0] = "toves"
+@test_throws BoundsError buf[end+1:1] = "did"
+@test_throws BoundsError buf[1:end+1] = "gyre"
+@test_throws BoundsError buf[1:1+end] = "and"
+@test_throws BoundsError buf[1+end:1] = "gymble"
+@test_throws BoundsError buf[end-1:end+1] = "in"
+@test_throws BoundsError buf[end:end+1] = "the"
+@test_throws BoundsError buf[end+1:end+1] = "wabe"
 
 deleteat!(buf, 2)
-@assert buf[:] == ["alpha", "boom", "c", "d"]
+@assert buf[:] == ["alpha", "boom", ".", "d"]
 deleteat!(buf, 3:4)
 @assert buf[:] == ["alpha", "boom"]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+using Base.Test
+
 using Neovim
 import Neovim: get_buffers, set_line, get_line, vim_eval, command, get_var
 import Neovim: on_notify, on_request
@@ -18,10 +20,31 @@ buf = current_buffer(nvim)
 
 buf[:] = ["alpha", "beta", "gamma"]
 @assert buf[:] == ["alpha", "beta", "gamma"]
+@assert buf[1] == "alpha"
 @assert buf[1:3] == ["alpha", "beta", "gamma"]
-@assert buf[2:3] == ["beta", "gamma"]
+@assert buf[1:1] == ["alpha"]
 @assert buf[end-1:end] == ["beta", "gamma"]
+@assert buf[1+end-1:end] == ["gamma"]
+@assert buf[end-1+1:1+end-1] == ["gamma"]
 @assert buf[end-1:2] == ["beta"]
+@assert buf[end+1-1] == "gamma"
+@assert buf[1+end-1] == "gamma"
+@assert buf[2:1] == []
+@assert buf[1:0] == []
+
+@test_throws BoundsError buf[0]
+@test_throws BoundsError buf[-1]
+@test_throws BoundsError buf[end+1]
+@test_throws BoundsError buf[-1:1]
+@test_throws BoundsError buf[0:1]
+@test_throws BoundsError buf[-1:0]
+@test_throws BoundsError buf[end+1:1]
+@test_throws BoundsError buf[1:end+1]
+@test_throws BoundsError buf[1:1+end]
+@test_throws BoundsError buf[1+end:1]
+@test_throws BoundsError buf[end-1:end+1]
+@test_throws BoundsError buf[end:end+1]
+@test_throws BoundsError buf[end+1:end+1]
 
 buf[2] = "beta-ish"
 @assert buf[:] == ["alpha", "beta-ish", "gamma"]


### PR DESCRIPTION
Most of the changes involve ensuring the validity of end-relative indices. There's also a bit of sugar added to setting a range to a specific value. The functionality should generally match that of real arrays.
