### PR TITLE
Add buffer (get|set)index methods for Colon argument

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -38,6 +38,7 @@ Base.colon(a::Integer, b::EndRelIndex) = CappedRange(a, b)
 Base.colon(a::EndRelIndex, b::Union(Integer, EndRelIndex)) = CappedRange(a, b)
 
 Base.getindex(b::Buffer, r::CappedRange) = get_line_slice(b, r.start, r.stop, true, true)
+Base.getindex(b::Buffer, ::Colon) = b[1:end]
 function Base.getindex(b::Buffer, i::Union(Integer, EndRelIndex))
     line = b[i:i]
     length(line) > 0 ? line[1] : ""
@@ -52,6 +53,7 @@ end
 
 Base.setindex!(b::Buffer, lines::Array, r::CappedRange) =
     set_line_slice(b, r.start, r.stop, true, true, lines)
+Base.setindex!(b::Buffer, lines::Array, ::Colon) = b[1:end] = lines
 Base.setindex!(b::Buffer, s::String, i::Integer) = b[i:i] = [s]
 Base.setindex!(b::Buffer, s::String, i::EndRelIndex) = b[i:i] = [s]
 Base.setindex!(b::Buffer, s::String, r::CappedRange) = b[r] = [s]


### PR DESCRIPTION
In the latest nightly, `arr[:]` now explicitly calls the *index methods  with `::Colon`.
