### PR TITLE
Julia plugin host

### DIFF
--- a/autoload/julia_neo.vim
+++ b/autoload/julia_neo.vim
@@ -3,7 +3,7 @@ function! julia_neo#RequireJuliaHost(host)
   let args = ['-e', 'using Neovim; start_host()']
 
   try
-    return rpcstart("julia", args)
+    return rpcstart(a:host.orig_name, args)
   catch
     echomsg v:exception
   endtry

--- a/autoload/julia_neo.vim
+++ b/autoload/julia_neo.vim
@@ -3,7 +3,7 @@ function! julia_neo#RequireJuliaHost(host)
   let args = ['-e', 'using Neovim; start_host()']
 
   try
-    return rpcstart(a:host.orig_name, args)
+    return rpcstart("julia", args)
   catch
     echomsg v:exception
   endtry

--- a/autoload/julia_neo.vim
+++ b/autoload/julia_neo.vim
@@ -1,9 +1,9 @@
-function! s:RequireJuliaHost(name)
+function! julia_neo#RequireJuliaHost(host)
   " Julia host arguments
   let args = ['-e', 'using Neovim; start_host()']
 
   try
-    return rpcstart('julia', args)
+    return rpcstart(a:host.orig_name, args)
   catch
     echomsg v:exception
   endtry
@@ -14,5 +14,3 @@ function! s:RequireJuliaHost(name)
         \ 'in Neovim log, so it may contain useful information. '.
         \ 'See also ~/.nvimlog.'
 endfunction
-
-call remote#host#Register('julia', '*.jl', function('s:RequireJuliaHost'))

--- a/plugin/julia-neo.vim
+++ b/plugin/julia-neo.vim
@@ -1,0 +1,18 @@
+function! s:RequireJuliaHost(name)
+  " Julia host arguments
+  let args = ['-e', 'using Neovim; start_host()']
+
+  try
+    return rpcstart('julia', args)
+  catch
+    echomsg v:exception
+  endtry
+  throw 'Failed to load Julia host. You can try to see what happened '.
+        \ 'by starting Neovim with the environment variable '.
+        \ '$NVIM_JL_DEBUG set to a file and opening '.
+        \ 'the generated log file. Also, the host stderr will be available '.
+        \ 'in Neovim log, so it may contain useful information. '.
+        \ 'See also ~/.nvimlog.'
+endfunction
+
+call remote#host#Register('julia', '*.jl', function('s:RequireJuliaHost'))

--- a/plugin/julia_neo.vim
+++ b/plugin/julia_neo.vim
@@ -1,0 +1,1 @@
+call remote#host#Register('julia', '*.jl', function('julia_neo#RequireJuliaHost'))

--- a/src/Neovim.jl
+++ b/src/Neovim.jl
@@ -31,10 +31,16 @@ end
 function nvim_child(args...)
     # make stdio private. Reversed since from nvim's perspective
     input, output = STDOUT, STDIN
-    debug = open("NEOVIM_JL_DEBUG","w") # TODO: make env var
-    redirect_stdout(debug)
-    redirect_stderr(debug)
+    if haskey(ENV, "NEOVIM_JL_DEBUG")
+        debug = open(ENV["NEOVIM_JL_DEBUG"], "w")
+        redirect_stdout(debug)
+        redirect_stderr(debug)
+    else
+        redirect_stdout()
+        redirect_stderr()
+    end
     redirect_stdin()
+
     NvimClient(input, output, args...)
 end
 

--- a/src/Neovim.jl
+++ b/src/Neovim.jl
@@ -4,7 +4,7 @@ using Compat
 using MsgPack
 import MsgPack: pack, unpack
 
-export NvimClient, nvim_connect, nvim_env, nvim_spawn, nvim_child
+export NvimClient, nvim_connect, nvim_env, nvim_spawn, nvim_child, start_host
 export Buffer, Tabpage, Window
 export reply_result, reply_error
 
@@ -14,6 +14,7 @@ abstract NvimObject
 include("client.jl")
 include("api_gen.jl")
 include("interface.jl")
+include("plugin_host.jl")
 
 # too inconvenient api to supply handler here?
 function nvim_connect(path::ByteString, args...)

--- a/src/client.jl
+++ b/src/client.jl
@@ -27,7 +27,7 @@ end
 # this is probably not most efficient in the common case (no contention)
 # but it's the simplest way to assure task-safety of reading from the stream
 function readloop(c::NvimClient, handler)
-    while true
+    while !eof(c.output)
         msg = unpack(c.output)
         kind = msg[1]::Int
         if kind == RESPONSE

--- a/src/client.jl
+++ b/src/client.jl
@@ -38,18 +38,20 @@ function readloop(c::NvimClient, handler)
             try
                 on_notify(handler, c, bytestring(msg[2]), retconvert(Any, c, msg[3]))
             catch err
-                println("Excetion caught in notification handler")
-                println(err)
+                println(STDERR, "Excetion caught in notification handler")
+                println(STDERR, err)
             end
         elseif kind == REQUEST
             serial = msg[2]::Int
             try
                 on_request(handler, c, serial, bytestring(msg[3]), retconvert(Any, c, msg[4]))
             catch err
-                println("Excetion caught in request handler")
-                println(err)
+                reply_error(c, serial, "Exception caught in request handler")
+                println(STDERR, "Excetion caught in request handler")
+                println(STDERR, err)
             end
         end
+        flush(STDERR)
     end
 end
 

--- a/src/plugin_host.jl
+++ b/src/plugin_host.jl
@@ -1,0 +1,102 @@
+start_host() = wait(nvim_child(HostHandler()).reader)
+
+immutable HostHandler
+    loaded_plugins::Set{String} # plugin file paths
+    proc_callbacks::Dict{String, Function}
+end
+
+function HostHandler()
+    HostHandler(Set{String}(), Dict{String, Function}())
+end
+
+# names/methods for invoked cmds/fns have the form:
+#   <file path>:(command|function|autocmd):<procedure name>
+function on_notify(::HostHandler, c, name, args)
+    plugin_file, proc_type, proc_name = split(name, ':')
+end
+
+function on_request(h::HostHandler, c, serial, method, args)
+    if method == "specs" # called on UpdateRemotePlugins
+        reply_result(c, serial, get_specs(args...))
+    else
+        reply_result(c, serial, 42)
+    end
+end
+
+function get_specs(plugin_file)
+    plugin = nothing
+    try
+        plugin = decorate(plugin_file)
+    end
+
+    fn_specs = {}
+    global plug(proc_type, name, handler, opt_args...) = begin
+        conf = Dict{String, Any}()
+        conf["type"] = proc_type
+        conf["name"] = name
+        opts = Dict{String, Any}()
+        for (opt_k, opt_v) in opt_args
+            opts[string(opt_k)] = opt_v
+        end
+        conf["opts"] = opts
+        conf["sync"] = pop!(opts, "sync", 0)
+        push!(fn_specs, conf)
+    end
+
+    eval(plugin)
+
+    fn_specs
+end
+
+# finds constructs that look like decorators (i.e. macrocall then function)
+# and then adds the function name as the last argument to the macrocall
+function decorate(file_name::String)
+    ast = (open(readall, file_name) |> parse)::Expr
+
+    q = Array(Expr, 0)
+    candidate_fns = Array((Expr, Expr), 0)
+    push!(q, ast)
+    while length(q) > 0
+        expr = shift!(q)
+        for (i, arg) in enumerate(expr.args)
+            if typeof(arg) != Expr continue end
+            if arg.head == :macrocall && expr.args[i + 2].head == :function
+                # `i + 2` to skip LineNumberNode
+                fn_name = expr.args[i + 2].args[1].args[1]
+                push!(arg.args, fn_name)
+            end
+            push!(q, arg)
+        end
+    end
+    ast
+end
+
+# called by result of "decorator" macros in plugin files
+function plug(proc_type, name, handler, opts...) end
+
+macro command(args...)
+    call_plug(:command, args...)
+end
+
+macro autocmd(args...)
+    call_plug(:autocmd, args...)
+end
+
+macro fn(args...)
+    call_plug(:function, args...)
+end
+
+function call_plug(proc_type, name, opts...)
+    if length(opts) == 0
+        return symbol("")
+    end
+
+    handler = opts[end]
+    fcall_args = {string(proc_type), string(name), string(handler)}
+    for opt in opts[1:end-1]
+        var, val = opt.args
+        push!(fcall_args, Expr(:tuple, string(var), val))
+    end
+
+    Expr(:call, :plug, fcall_args...)
+end

--- a/src/plugin_host.jl
+++ b/src/plugin_host.jl
@@ -1,18 +1,15 @@
-start_host() = try wait(nvim_child(HostHandler()).reader) end
+start_host() = try wait(nvim_child(HostHandler())) end
 
 immutable HostHandler
-    loaded_plugins::Set{String} # plugin file paths
-    proc_callbacks::Dict{String, Function}
-end
-
-function HostHandler()
-    HostHandler(Set{String}(), Dict{String, Function}())
+    specs::Dict{ByteString, Any} # plugin file paths
+    proc_callbacks::Dict{ByteString, Function}
+    HostHandler() = new(Dict{ByteString, Any}(), Dict{ByteString, Function}())
 end
 
 # names/methods for invoked cmds/fns have the form:
 #   <file path>:(command|function|autocmd):<procedure name>
 function on_notify(h::HostHandler, c, name::String, args::Vector{Any})
-    proc = require_plug(h, name)
+    proc = require_callback(h, name)
 
     if proc == nothing
         println(STDERR, "Callback for notification $name not defined.\n")
@@ -27,9 +24,10 @@ end
 
 function on_request(h::HostHandler, c, serial, method, args)
     if method == "specs" # called on UpdateRemotePlugins
-        reply_result(c, serial, get_specs(args...))
+        reply_result(c, serial, require_plugin(h, args...))
+        println(STDERR, h)
     else
-        proc = require_plug(h, method)
+        proc = require_callback(h, method)
 
         if proc == nothing
             emsg = "Callback for request $method not defined."
@@ -46,106 +44,58 @@ function on_request(h::HostHandler, c, serial, method, args)
     end
 end
 
-function require_plug(h::HostHandler, name::String)
+function require_callback(h::HostHandler, name::ByteString)
     (plugin_file, proc_id) = split(name, ':', 2)
-
-    if plugin_file ∉ h.loaded_plugins
-        cbs = get_callbacks(plugin_file)
-        merge!(h.proc_callbacks, cbs)
-    end
-
+    require_plugin(h, plugin_file)
     get(h.proc_callbacks, name, nothing)
 end
 
-function get_specs(plugin_file)
-    plugin = nothing
-    try
-        plugin = decorate(plugin_file)
+function require_plugin(h::HostHandler, filename)
+    if haskey(h.specs, filename)
+        return h.specs[filename]
     end
-
-    fn_specs = {}
-    global plug(proc_type, name, handler, opt_args...) = begin
-        conf = Dict{String, Any}()
-        conf["type"] = proc_type
-        conf["name"] = name
-        opts = Dict{String, Any}()
-        for (opt_k, opt_v) in opt_args
-            opts[string(opt_k)] = opt_v
-        end
-        conf["opts"] = opts
-        conf["sync"] = pop!(opts, "sync", 0)
-        push!(fn_specs, conf)
-    end
-
+    h.specs[filename] = specs = Any[]
+    tls = task_local_storage()
+    tls[:nvim_plugin_host] = h
+    tls[:nvim_plugin_filename] = filename
     try
-        eval(plugin)
+        require(filename)
     catch err
-        println(STDERR, "Error while loading plugin " * plugin_file)
+        println(STDERR, "Error while loading plugin " * filename)
         println(STDERR, err)
     end
-
-    fn_specs
+    delete!(tls, :nvim_plugin_host)
+    delete!(tls, :nvim_plugin_filename)
+    specs
 end
 
-function get_callbacks(plugin_file)
-    plugin = nothing
-    try
-        plugin = decorate(plugin_file)
-    end
-
-    proc_callbacks = Array((String, Expr), 0)
-    global plug(proc_type, name, handler, opt_args...) = begin
-        pattern = ""
-        for arg in opt_args
-            if arg[1] == "pattern"
-                pattern = ":" * arg[2]
-            end
-        end
-
-        proc_name = "$plugin_file:$proc_type:$name$pattern"
-        push!(proc_callbacks, (proc_name, parse(handler)))
-    end
-
-    try
-        eval(plugin)
-    catch err
-        println(STDERR, "Error while loading plugin " * plugin_file)
-        println(STDERR, err)
-    end
-
-    extract_fns(x) = (x[1], eval(x[2]))
-    Dict{String, Function}(map(extract_fns, proc_callbacks))
-end
-
-# finds constructs that look like decorators (i.e. macrocall then function)
-# and then adds the function name as the last argument to the macrocall
-function decorate(file_name::String)
-    ast = (open(readall, file_name) |> parse)::Expr
-    module_name = ast.args[2]
-
-    q = Array(Expr, 0)
-    candidate_fns = Array((Expr, Expr), 0)
-    push!(q, ast)
-    while length(q) > 0
-        expr = shift!(q)
-        for (i, arg) in enumerate(expr.args)
-            if typeof(arg) != Expr continue end
-            if arg.head == :macrocall && expr.args[i + 2].head == :function
-                # `i + 2` to skip LineNumberNode
-                fn_name = expr.args[i + 2].args[1].args[1]
-                push!(arg.args, symbol("$module_name.$fn_name"))
-            elseif arg.head == :macrocall && contains(string(arg.args[1]), "Neovim")
-                deleteat!(expr.args, i)
-                println(STDERR, "Bad decorator in " * file_name * ": " * string(arg))
-            end
-            push!(q, arg)
-        end
-    end
-    ast
-end
 
 # called by result of "decorator" macros in plugin files
-function plug(proc_type, name, handler, opts...) end
+function plug(proc_type, name, handler, opt_args)
+    conf = Dict{ByteString, Any}()
+    conf["type"] = proc_type
+    conf["name"] = name
+    opts = Dict{ByteString, Any}()
+    for (opt_k, opt_v) in opt_args
+        opts[string(opt_k)] = opt_v
+    end
+    conf["opts"] = opts
+    conf["sync"] = pop!(opts, "sync", 0)
+    tls = task_local_storage()
+    h = tls[:nvim_plugin_host]
+    filename = tls[:nvim_plugin_filename]
+    push!(h.specs[filename], conf)
+
+    pattern = ""
+    for arg in opt_args
+        if arg[1] == "pattern"
+            pattern = ":" * arg[2]
+        end
+    end
+
+    proc_name = "$filename:$proc_type:$name$pattern"
+    h.proc_callbacks[proc_name] = handler
+end
 
 macro command(args...)
     call_plug(:command, args...)
@@ -159,10 +109,14 @@ macro fn(args...)
     call_plug(:function, args...)
 end
 
-function call_plug(proc_type, name, opts...)
+#WIP
+function call_plug(proc_type, args...)
     if length(opts) == 0
         return symbol("")
     end
+    #if length(args)== 1 && args[1].head = :->
+    #    opts, call = args[1].args
+    #end
 
     handler = opts[end]
     fcall_args = {string(proc_type), string(name), string(handler)}
@@ -173,3 +127,4 @@ function call_plug(proc_type, name, opts...)
 
     Expr(:call, :plug, fcall_args...)
 end
+


### PR DESCRIPTION
The syntax for plugins is similar to that used for Python except `function` is replaced by `fn` since the former is a reserved word.

Example plugin: https://gist.github.com/nhynes/41a30e4468f50a044a38
