### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-  - release
+  - 0.4
   - nightly
 before_install:
   - sudo apt-get update -qq;


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested